### PR TITLE
feat: show reviewed PRs and unresolved comment counts, badge count mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to PR Pulse are documented in this file.
 
+## [1.4.0] – 2026-07-02
+
+- **Reviewed PRs in To Review tab**: Added a "Review Status" filter toggle so users can choose to show PRs they've already reviewed alongside pending ones. A new `getReviewedPRs()` GitHub search query fetches reviewed-but-unmerged PRs, merged into the review requests list with dedup. (Resolves [#3](https://github.com/jammutkarsh/pr-pulse/issues/3))
+- **Unresolved comment count for changes-requested PRs**: When a review status is "Changes Requested," the label now shows the number of unresolved review threads (e.g., "Changes Requested (3)"). Count is fetched via the PR comments API. (Resolves [#20](https://github.com/jammutkarsh/pr-pulse/issues/20))
+- **Badge count mode**: New setting to choose whether the extension icon badge shows total PRs or the count matching active filters. Added to both the settings page and the service worker message handlers.
+- **PR card UX improvements**: Review status row is now clickable (deep-links to the relevant review when changes are requested); both check and review status rows show an external-link icon on hover.
+- **Dependency updates**: Bumped tsx, vite, rolldown, esbuild, and postcss to latest.
+
 ## [1.3.2] – 2026-04-20
 
 ### 2026-04-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,10 @@ All notable changes to PR Pulse are documented in this file.
 
 ## [1.4.0] – 2026-07-02
 
-- **Reviewed PRs in To Review tab**: Added a "Review Status" filter toggle so users can choose to show PRs they've already reviewed alongside pending ones. A new `getReviewedPRs()` GitHub search query fetches reviewed-but-unmerged PRs, merged into the review requests list with dedup. (Resolves [#3](https://github.com/jammutkarsh/pr-pulse/issues/3))
-- **Unresolved comment count for changes-requested PRs**: When a review status is "Changes Requested," the label now shows the number of unresolved review threads (e.g., "Changes Requested (3)"). Count is fetched via the PR comments API. (Resolves [#20](https://github.com/jammutkarsh/pr-pulse/issues/20))
-- **Badge count mode**: New setting to choose whether the extension icon badge shows total PRs or the count matching active filters. Added to both the settings page and the service worker message handlers.
-- **PR card UX improvements**: Review status row is now clickable (deep-links to the relevant review when changes are requested); both check and review status rows show an external-link icon on hover.
-- **Dependency updates**: Bumped tsx, vite, rolldown, esbuild, and postcss to latest.
+- **Reviewed PRs in To Review tab**: Added a "Review Status" filter toggle to show PRs you've already reviewed alongside pending ones. By default, only approved PRs are hidden — PRs with requested changes remain visible since they still need action. (Resolves [#3](https://github.com/jammutkarsh/pr-pulse/issues/3))
+- **Unresolved comment counts**: When a review has requested changes, the status label now shows the number of open review threads (e.g., "Changes Requested (3)"). (Resolves [#20](https://github.com/jammutkarsh/pr-pulse/issues/20))
+- **Badge count mode**: New setting to choose what the icon badge shows — total PRs in your default view, or only those matching your active filters. The badge always sticks to your pinned tab and is not affected by temporary tab switches in the popup.
+- **Clickable review status**: The review status row on each PR card is now a link — clicking deep-links to the relevant review when changes are requested. Check and review status rows also show an external-link icon on hover.
 
 ## [1.3.2] – 2026-04-20
 

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ npm install
 npm run generate
 ```
 
-2. Chrome / Chromium: Run `npm run generate:chrome`, open [chrome://extensions](chrome://extensions), enable **Developer mode**, click **Load unpacked**, and select the `pr-pulse/dist/chrome` folder.
-3. Firefox: Run `npm run generate:firefox`, open [about:debugging#/runtime/this-firefox](about:debugging#/runtime/this-firefox), click **Load Temporary Add-on**, and select `pr-pulse/dist/firefox/manifest.json`.
+2. Chrome / Chromium: Run `npm run generate:chrome`, open `chrome://extensions`, enable **Developer mode**, click **Load unpacked**, and select the `pr-pulse/dist/chrome` folder.
+3. Firefox: Run `npm run generate:firefox`, open `about:debugging#/runtime/this-firefox`, click **Load Temporary Add-on**, and select `pr-pulse/dist/firefox/manifest.json`.
 4. Pin the extension to your toolbar for easy access
 
 <!-- ## Practical Value

--- a/extension/global.d.ts
+++ b/extension/global.d.ts
@@ -1,1 +1,3 @@
+declare module '*.css' {}
+
 declare const __BROWSER_TARGET__: 'chrome' | 'firefox';

--- a/extension/lib/provider-manager.ts
+++ b/extension/lib/provider-manager.ts
@@ -69,15 +69,30 @@ class ProviderManager {
 		return this.#ensureProvider().getReviewRequests();
 	}
 
+	getReviewedPRs(): Promise<PullRequest[]> {
+		return this.#ensureProvider().getReviewedPRs();
+	}
+
 	async fetchAllPullRequests(): Promise<PullRequestData> {
-		const [myPRs, reviewRequests] = await Promise.all([
+		const [myPRs, reviewRequests, reviewedPRs] = await Promise.all([
 			this.getMyPullRequests(),
 			this.getReviewRequests(),
+			this.getReviewedPRs(),
 		]);
+
+		// ponytail: merge reviewed PRs into reviewRequests, dedupe by id — fetchAllPullRequests does 3 parallel queries
+		const seen = new Set(reviewRequests.map((pr) => pr.id));
+		const mergedReviewRequests = [...reviewRequests];
+		for (const pr of reviewedPRs) {
+			if (!seen.has(pr.id)) {
+				seen.add(pr.id);
+				mergedReviewRequests.push(pr);
+			}
+		}
 
 		return {
 			myPRs,
-			reviewRequests,
+			reviewRequests: mergedReviewRequests,
 			lastFetched: null,
 		};
 	}

--- a/extension/lib/provider-manager.ts
+++ b/extension/lib/provider-manager.ts
@@ -1,7 +1,7 @@
 import { ProviderError } from './errors';
 import { GitHubProvider } from './providers/github-provider';
 import type { BaseProvider } from './providers/base-provider';
-import type { ProviderConfig, PullRequestData, ProviderType, User, PullRequest } from './types';
+import type { ProviderConfig, PullRequestData, ProviderType } from './types';
 
 type ProviderClass = new (config?: ProviderConfig) => BaseProvider;
 
@@ -37,10 +37,6 @@ class ProviderManager {
 		this.provider = provider;
 	}
 
-	getProvider(): BaseProvider | null {
-		return this.provider;
-	}
-
 	hasProvider(): boolean {
 		return this.provider !== null;
 	}
@@ -53,34 +49,17 @@ class ProviderManager {
 		return this.provider;
 	}
 
-	authenticate(): Promise<User> {
-		return this.#ensureProvider().authenticate();
-	}
-
-	getUser(): Promise<User> {
-		return this.#ensureProvider().getUser();
-	}
-
-	getMyPullRequests(): Promise<PullRequest[]> {
-		return this.#ensureProvider().getMyPullRequests();
-	}
-
-	getReviewRequests(): Promise<PullRequest[]> {
-		return this.#ensureProvider().getReviewRequests();
-	}
-
-	getReviewedPRs(): Promise<PullRequest[]> {
-		return this.#ensureProvider().getReviewedPRs();
-	}
-
 	async fetchAllPullRequests(): Promise<PullRequestData> {
+		const provider = this.#ensureProvider();
+
+		// ponytail: 3 parallel queries — the 3rd (reviewed-by) adds one extra GitHub search call per refresh.
+		// Gate behind a flag if rate limits ever matter.
 		const [myPRs, reviewRequests, reviewedPRs] = await Promise.all([
-			this.getMyPullRequests(),
-			this.getReviewRequests(),
-			this.getReviewedPRs(),
+			provider.getMyPullRequests(),
+			provider.getReviewRequests(),
+			provider.getReviewedPRs(),
 		]);
 
-		// ponytail: merge reviewed PRs into reviewRequests, dedupe by id — fetchAllPullRequests does 3 parallel queries
 		const seen = new Set(reviewRequests.map((pr) => pr.id));
 		const mergedReviewRequests = [...reviewRequests];
 		for (const pr of reviewedPRs) {

--- a/extension/lib/providers/base-provider.ts
+++ b/extension/lib/providers/base-provider.ts
@@ -28,6 +28,11 @@ export class BaseProvider {
 		throw new Error('getReviewRequests() not implemented');
 	}
 
+	// fallow-ignore-next-line unused-class-member
+	async getReviewedPRs(): Promise<PullRequest[]> {
+		throw new Error('getReviewedPRs() not implemented');
+	}
+
 	async getPullRequestDetails(repoFullName: string, prNumber: number): Promise<unknown> {
 		void repoFullName;
 		void prNumber;

--- a/extension/lib/providers/base-provider.ts
+++ b/extension/lib/providers/base-provider.ts
@@ -1,6 +1,6 @@
 import type { ProviderConfig, PullRequest, PullRequestChecks, PullRequestReviews, User } from '../types';
 
-export class BaseProvider {
+export abstract class BaseProvider {
 	name = 'base';
 	displayName = 'Base Provider';
 	baseUrl = '';
@@ -10,44 +10,12 @@ export class BaseProvider {
 		this.token = config.token || '';
 	}
 
-	async authenticate(): Promise<User> {
-		throw new Error('authenticate() not implemented');
-	}
-
-	async getUser(): Promise<User> {
-		throw new Error('getUser() not implemented');
-	}
-
-	// fallow-ignore-next-line unused-class-member
-	async getMyPullRequests(): Promise<PullRequest[]> {
-		throw new Error('getMyPullRequests() not implemented');
-	}
-
-	// fallow-ignore-next-line unused-class-member
-	async getReviewRequests(): Promise<PullRequest[]> {
-		throw new Error('getReviewRequests() not implemented');
-	}
-
-	// fallow-ignore-next-line unused-class-member
-	async getReviewedPRs(): Promise<PullRequest[]> {
-		throw new Error('getReviewedPRs() not implemented');
-	}
-
-	async getPullRequestDetails(repoFullName: string, prNumber: number): Promise<unknown> {
-		void repoFullName;
-		void prNumber;
-		throw new Error('getPullRequestDetails() not implemented');
-	}
-
-	async getCheckStatus(repoFullName: string, commitSha: string): Promise<PullRequestChecks> {
-		void repoFullName;
-		void commitSha;
-		throw new Error('getCheckStatus() not implemented');
-	}
-
-	async getReviewStatus(repoFullName: string, prNumber: number): Promise<PullRequestReviews> {
-		void repoFullName;
-		void prNumber;
-		throw new Error('getReviewStatus() not implemented');
-	}
+	abstract authenticate(): Promise<User>;
+	abstract getUser(): Promise<User>;
+	abstract getMyPullRequests(): Promise<PullRequest[]>;
+	abstract getReviewRequests(): Promise<PullRequest[]>;
+	abstract getReviewedPRs(): Promise<PullRequest[]>;
+	abstract getPullRequestDetails(repoFullName: string, prNumber: number): Promise<unknown>;
+	abstract getCheckStatus(repoFullName: string, commitSha: string): Promise<PullRequestChecks>;
+	abstract getReviewStatus(repoFullName: string, prNumber: number, requestedReviewers?: string[]): Promise<PullRequestReviews>;
 }

--- a/extension/lib/providers/github-provider.ts
+++ b/extension/lib/providers/github-provider.ts
@@ -217,6 +217,11 @@ export class GitHubProvider extends BaseProvider {
 		return this.#fetchPRsWithQuery('review-requested:@me+type:pr+state:open');
 	}
 
+	// fallow-ignore-next-line unused-class-member
+	getReviewedPRs(): Promise<PullRequest[]> {
+		return this.#fetchPRsWithQuery('reviewed-by:@me+-author:@me+type:pr+state:open');
+	}
+
 	async getPullRequestDetails(repoFullName: string, prNumber: number): Promise<PullRequestDetails> {
 		const data = await this.#request<{
 			head?: { ref?: string; sha?: string };
@@ -306,7 +311,7 @@ export class GitHubProvider extends BaseProvider {
 	}
 
 	async getReviewStatus(repoFullName: string, prNumber: number, requestedReviewers: string[] = []): Promise<PullRequestReviews> {
-		const data = await this.#request<Array<{ state: string; user: { login: string; avatar_url: string } }>>(`/repos/${repoFullName}/pulls/${prNumber}/reviews`);
+		const data = await this.#request<Array<{ id: number; state: string; user: { login: string; avatar_url: string } }>>(`/repos/${repoFullName}/pulls/${prNumber}/reviews`);
 		const reRequestedSet = new Set(requestedReviewers);
 		const reviewerMap = new Map<string, { login: string; avatarUrl: string; state: string }>();
 
@@ -328,6 +333,29 @@ export class GitHubProvider extends BaseProvider {
 
 		const reviewers = Array.from(reviewerMap.values());
 		const status = this.#resolveReviewVerdict(reviewers, requestedReviewers.length > 0);
-		return { status, reviewers, pendingReviewers: requestedReviewers };
+
+		// Capture the most recent changes-requested review ID for deep-linking
+		let changesRequestedReviewId: number | undefined;
+		let unresolvedThreadCount: number | undefined;
+		if (status === 'changes_requested') {
+			const changesRequestedReviews = data.filter((r) => r.state === 'CHANGES_REQUESTED');
+			if (changesRequestedReviews.length > 0) {
+				changesRequestedReviewId = changesRequestedReviews[changesRequestedReviews.length - 1].id;
+				console.log(`PR #${prNumber}: found ${changesRequestedReviews.length} CHANGES_REQUESTED review(s), latest ID=${changesRequestedReviewId}`);
+			} else {
+				console.warn(`PR #${prNumber}: status=changes_requested but no CHANGES_REQUESTED reviews in data. Review states:`, data.map(r => `${r.id}:${r.state}`));
+			}
+
+			try {
+				const comments = await this.#request<Array<{ in_reply_to_id?: number }>>(
+					`/repos/${repoFullName}/pulls/${prNumber}/comments?per_page=100&sort=created&direction=desc`
+				);
+				unresolvedThreadCount = comments.filter((c) => !c.in_reply_to_id).length;
+			} catch (error) {
+				console.warn(`Failed to count unresolved threads for PR #${prNumber}:`, error);
+			}
+		}
+
+		return { status, reviewers, pendingReviewers: requestedReviewers, unresolvedThreadCount, changesRequestedReviewId };
 	}
 }

--- a/extension/lib/providers/github-provider.ts
+++ b/extension/lib/providers/github-provider.ts
@@ -93,11 +93,11 @@ export class GitHubProvider extends BaseProvider {
 		}
 	}
 
-	authenticate(): Promise<User> {
+	override authenticate(): Promise<User> {
 		return this.getUser();
 	}
 
-	async getUser(): Promise<User> {
+	override async getUser(): Promise<User> {
 		const data = await this.#request<{ login: string; avatar_url: string; name?: string }>('/user');
 		return {
 			login: data.login,
@@ -207,22 +207,19 @@ export class GitHubProvider extends BaseProvider {
 		);
 	}
 
-	// fallow-ignore-next-line unused-class-member
-	getMyPullRequests(): Promise<PullRequest[]> {
+	override getMyPullRequests(): Promise<PullRequest[]> {
 		return this.#fetchPRsWithQuery('author:@me+type:pr+state:open');
 	}
 
-	// fallow-ignore-next-line unused-class-member
-	getReviewRequests(): Promise<PullRequest[]> {
+	override getReviewRequests(): Promise<PullRequest[]> {
 		return this.#fetchPRsWithQuery('review-requested:@me+type:pr+state:open');
 	}
 
-	// fallow-ignore-next-line unused-class-member
-	getReviewedPRs(): Promise<PullRequest[]> {
+	override getReviewedPRs(): Promise<PullRequest[]> {
 		return this.#fetchPRsWithQuery('reviewed-by:@me+-author:@me+type:pr+state:open');
 	}
 
-	async getPullRequestDetails(repoFullName: string, prNumber: number): Promise<PullRequestDetails> {
+	override async getPullRequestDetails(repoFullName: string, prNumber: number): Promise<PullRequestDetails> {
 		const data = await this.#request<{
 			head?: { ref?: string; sha?: string };
 			base?: {
@@ -278,7 +275,7 @@ export class GitHubProvider extends BaseProvider {
 		return allSuccess ? 'success' : 'pending';
 	}
 
-	async getCheckStatus(repoFullName: string, sha: string): Promise<PullRequestChecks> {
+	override async getCheckStatus(repoFullName: string, sha: string): Promise<PullRequestChecks> {
 		if (!sha) {
 			return { status: 'unknown', details: [] };
 		}
@@ -310,7 +307,7 @@ export class GitHubProvider extends BaseProvider {
 		return allApproved ? 'approved' : 'pending';
 	}
 
-	async getReviewStatus(repoFullName: string, prNumber: number, requestedReviewers: string[] = []): Promise<PullRequestReviews> {
+	override async getReviewStatus(repoFullName: string, prNumber: number, requestedReviewers: string[] = []): Promise<PullRequestReviews> {
 		const data = await this.#request<Array<{ id: number; state: string; user: { login: string; avatar_url: string } }>>(`/repos/${repoFullName}/pulls/${prNumber}/reviews`);
 		const reRequestedSet = new Set(requestedReviewers);
 		const reviewerMap = new Map<string, { login: string; avatarUrl: string; state: string }>();
@@ -341,7 +338,7 @@ export class GitHubProvider extends BaseProvider {
 			const changesRequestedReviews = data.filter((r) => r.state === 'CHANGES_REQUESTED');
 			if (changesRequestedReviews.length > 0) {
 				changesRequestedReviewId = changesRequestedReviews[changesRequestedReviews.length - 1].id;
-				console.log(`PR #${prNumber}: found ${changesRequestedReviews.length} CHANGES_REQUESTED review(s), latest ID=${changesRequestedReviewId}`);
+				console.debug(`PR #${prNumber}: found ${changesRequestedReviews.length} CHANGES_REQUESTED review(s), latest ID=${changesRequestedReviewId}`);
 			} else {
 				console.warn(`PR #${prNumber}: status=changes_requested but no CHANGES_REQUESTED reviews in data. Review states:`, data.map(r => `${r.id}:${r.state}`));
 			}

--- a/extension/lib/providers/github-provider.ts
+++ b/extension/lib/providers/github-provider.ts
@@ -336,7 +336,7 @@ export class GitHubProvider extends BaseProvider {
 
 		// Capture the most recent changes-requested review ID for deep-linking
 		let changesRequestedReviewId: number | undefined;
-		let unresolvedThreadCount: number | undefined;
+		let openThreadCount: number | undefined;
 		if (status === 'changes_requested') {
 			const changesRequestedReviews = data.filter((r) => r.state === 'CHANGES_REQUESTED');
 			if (changesRequestedReviews.length > 0) {
@@ -347,15 +347,16 @@ export class GitHubProvider extends BaseProvider {
 			}
 
 			try {
+				// ponytail: REST API doesn't expose resolved/unresolved, so we count top-level review comments as a proxy for open threads
 				const comments = await this.#request<Array<{ in_reply_to_id?: number }>>(
 					`/repos/${repoFullName}/pulls/${prNumber}/comments?per_page=100&sort=created&direction=desc`
 				);
-				unresolvedThreadCount = comments.filter((c) => !c.in_reply_to_id).length;
+				openThreadCount = comments.filter((c) => !c.in_reply_to_id).length;
 			} catch (error) {
-				console.warn(`Failed to count unresolved threads for PR #${prNumber}:`, error);
+				console.warn(`Failed to count open threads for PR #${prNumber}:`, error);
 			}
 		}
 
-		return { status, reviewers, pendingReviewers: requestedReviewers, unresolvedThreadCount, changesRequestedReviewId };
+		return { status, reviewers, pendingReviewers: requestedReviewers, openThreadCount, changesRequestedReviewId };
 	}
 }

--- a/extension/lib/storage.ts
+++ b/extension/lib/storage.ts
@@ -1,11 +1,12 @@
 import type { PullRequestData, Settings, StoredProviderConfig } from './types';
-import { storageLocalClear, storageLocalGet, storageLocalRemove, storageLocalSet } from './extension-api';
+import { storageLocalClear, storageLocalGet, storageLocalSet } from './extension-api';
 import { normalizeSettings } from './ui-config';
 
 const STORAGE_KEYS = {
 	PROVIDER: 'provider',
 	PULL_REQUESTS: 'pullRequests',
 	SETTINGS: 'settings',
+	BADGE_COUNT: 'badgeCount',
 } as const;
 
 async function get<T>(key: string): Promise<T | undefined> {
@@ -22,20 +23,12 @@ async function set<T>(key: string, value: T): Promise<void> {
 	return storageLocalSet({ [key]: value });
 }
 
-async function remove(key: string): Promise<void> {
-	return storageLocalRemove([key]);
-}
-
 async function getProvider(): Promise<StoredProviderConfig | undefined> {
 	return get<StoredProviderConfig>(STORAGE_KEYS.PROVIDER);
 }
 
 async function setProvider(provider: StoredProviderConfig): Promise<void> {
 	return set(STORAGE_KEYS.PROVIDER, provider);
-}
-
-async function clearProvider(): Promise<void> {
-	return remove(STORAGE_KEYS.PROVIDER);
 }
 
 async function getPullRequests(): Promise<PullRequestData> {
@@ -104,18 +97,21 @@ async function isAuthenticated(): Promise<boolean> {
 	return !!(provider && provider.token && provider.user);
 }
 
-async function isOnboardingComplete(): Promise<boolean> {
-	return isAuthenticated();
-}
-
 async function clearAll(): Promise<void> {
 	return storageLocalClear();
+}
+
+async function getBadgeCount(): Promise<number | undefined> {
+	return get<number>(STORAGE_KEYS.BADGE_COUNT);
+}
+
+async function setBadgeCount(count: number): Promise<void> {
+	return set(STORAGE_KEYS.BADGE_COUNT, count);
 }
 
 export const storage = {
 	getProvider,
 	setProvider,
-	clearProvider,
 	getPullRequests,
 	setPullRequests,
 	getSettings,
@@ -124,6 +120,7 @@ export const storage = {
 	setSettings,
 	updateSetting,
 	isAuthenticated,
-	isOnboardingComplete,
 	clearAll,
+	getBadgeCount,
+	setBadgeCount,
 };

--- a/extension/lib/storage.ts
+++ b/extension/lib/storage.ts
@@ -6,7 +6,6 @@ const STORAGE_KEYS = {
 	PROVIDER: 'provider',
 	PULL_REQUESTS: 'pullRequests',
 	SETTINGS: 'settings',
-	BADGE_COUNT: 'badgeCount',
 } as const;
 
 async function get<T>(key: string): Promise<T | undefined> {
@@ -101,14 +100,6 @@ async function clearAll(): Promise<void> {
 	return storageLocalClear();
 }
 
-async function getBadgeCount(): Promise<number | undefined> {
-	return get<number>(STORAGE_KEYS.BADGE_COUNT);
-}
-
-async function setBadgeCount(count: number): Promise<void> {
-	return set(STORAGE_KEYS.BADGE_COUNT, count);
-}
-
 export const storage = {
 	getProvider,
 	setProvider,
@@ -121,6 +112,4 @@ export const storage = {
 	updateSetting,
 	isAuthenticated,
 	clearAll,
-	getBadgeCount,
-	setBadgeCount,
 };

--- a/extension/lib/types.ts
+++ b/extension/lib/types.ts
@@ -44,7 +44,7 @@ export interface PullRequestReviews {
 	status: 'approved' | 'changes_requested' | 'pending';
 	reviewers: PullRequestReviewer[];
 	pendingReviewers?: string[];
-	unresolvedThreadCount?: number;
+	openThreadCount?: number;
 	changesRequestedReviewId?: number;
 }
 

--- a/extension/lib/types.ts
+++ b/extension/lib/types.ts
@@ -44,6 +44,8 @@ export interface PullRequestReviews {
 	status: 'approved' | 'changes_requested' | 'pending';
 	reviewers: PullRequestReviewer[];
 	pendingReviewers?: string[];
+	unresolvedThreadCount?: number;
+	changesRequestedReviewId?: number;
 }
 
 export interface PullRequest {
@@ -94,6 +96,7 @@ export interface Settings {
 	visibleColumns: string[];
 	pollingIntervalMs: number;
 	persistFilters: boolean;
+	badgeCountMode: 'total' | 'filters';
 	ui: UiConfig;
 }
 
@@ -109,6 +112,7 @@ export interface PopupFilters {
 	repos: string[];
 	ageRange: string;
 	drafts: 'only' | 'include' | 'exclude';
+	showReviewed: boolean;
 }
 
 export interface PopupAuthorFilterOption {
@@ -134,6 +138,7 @@ export type RuntimeMessage =
 	| { type: 'GET_PRS' }
 	| { type: 'UPDATE_SETTINGS'; settings: Partial<Settings> }
 	| { type: 'SETTINGS_UPDATED'; settings: Partial<Settings> }
+	| { type: 'UPDATE_BADGE_COUNT'; count: number }
 	| { type: 'CLEAR_ALL' };
 
 export interface ProviderErrorDetails {

--- a/extension/lib/types.ts
+++ b/extension/lib/types.ts
@@ -1,4 +1,4 @@
-export type ProviderType = 'github' | 'gitlab' | 'bitbucket';
+export type ProviderType = 'github';
 
 export interface User {
 	login: string;

--- a/extension/lib/ui-config.ts
+++ b/extension/lib/ui-config.ts
@@ -18,6 +18,7 @@ export const DEFAULT_SETTINGS: Settings = {
 	visibleColumns: ['title', 'author', 'checks', 'reviewStatus', 'repo', 'changes', 'jira'],
 	pollingIntervalMs: 600000,
 	persistFilters: true,
+	badgeCountMode: 'total',
 	ui: DEFAULT_UI_CONFIG,
 };
 

--- a/extension/lib/utils.ts
+++ b/extension/lib/utils.ts
@@ -1,3 +1,5 @@
+import type { PullRequest } from './types';
+
 export function extractJiraTicket(branchName: string): string | null {
 	if (!branchName) return null;
 	const match = branchName.match(/([A-Z]+-\d+)/i);
@@ -129,6 +131,51 @@ export function isValidTokenFormat(token: string): boolean {
 	const classicPattern = /^ghp_[a-zA-Z0-9]{36}$/;
 	const fineGrainedPattern = /^github_pat_[a-zA-Z0-9_]{22,}$/;
 	return classicPattern.test(token) || fineGrainedPattern.test(token);
+}
+
+export function filterPullRequests(
+	items: PullRequest[],
+	filters: {
+		authors?: string[];
+		owners?: string[];
+		repos?: string[];
+		drafts?: 'only' | 'include' | 'exclude';
+		showReviewed?: boolean;
+	}
+): PullRequest[] {
+	let result = items;
+
+	if (filters.drafts === 'exclude') {
+		result = result.filter((pr) => !pr.isDraft);
+	} else if (filters.drafts === 'only') {
+		result = result.filter((pr) => pr.isDraft);
+	}
+
+	if (filters.authors && filters.authors.length > 0) {
+		result = result.filter((pr) => {
+			const authorLogin = pr.author?.login || '';
+			return filters.authors!.includes(authorLogin);
+		});
+	}
+
+	if (filters.repos && filters.repos.length > 0) {
+		result = result.filter((pr) => {
+			return filters.repos!.includes(pr.repoFullName);
+		});
+	}
+
+	if (filters.owners && filters.owners.length > 0) {
+		result = result.filter((pr) => {
+			const ownerLogin = pr.repoOwner?.login || pr.repoFullName?.split('/')[0] || '';
+			return filters.owners!.includes(ownerLogin);
+		});
+	}
+
+	if (filters.showReviewed === false) {
+		result = result.filter((pr) => pr.reviews.status !== 'approved');
+	}
+
+	return result;
 }
 
 export function safeParseInt(value: unknown, defaultValue = 0): number {

--- a/extension/lib/utils.ts
+++ b/extension/lib/utils.ts
@@ -29,12 +29,16 @@ export function getJiraUrl(ticketId: string, baseUrl: string): string {
 	return `${sanitizeJiraUrl(baseUrl)}/browse/${ticketId}`;
 }
 
-export function getReviewStatusDisplay(status: string) {
+export function getReviewStatusDisplay(status: string, unresolvedCount?: number) {
 	switch (status) {
 		case 'approved':
 			return { label: 'Approved', icon: '✓', className: 'status-approved' };
-		case 'changes_requested':
-			return { label: 'Changes Requested', icon: '✗', className: 'status-changes' };
+		case 'changes_requested': {
+			const label = unresolvedCount && unresolvedCount > 0
+				? `Changes Requested (${unresolvedCount})`
+				: 'Changes Requested';
+			return { label, icon: '✗', className: 'status-changes' };
+		}
 		case 'pending':
 		default:
 			return { label: 'Review Pending', icon: '⏳', className: 'status-pending' };

--- a/extension/lib/utils.ts
+++ b/extension/lib/utils.ts
@@ -29,13 +29,13 @@ export function getJiraUrl(ticketId: string, baseUrl: string): string {
 	return `${sanitizeJiraUrl(baseUrl)}/browse/${ticketId}`;
 }
 
-export function getReviewStatusDisplay(status: string, unresolvedCount?: number) {
+export function getReviewStatusDisplay(status: string, openThreadCount?: number) {
 	switch (status) {
 		case 'approved':
 			return { label: 'Approved', icon: '✓', className: 'status-approved' };
 		case 'changes_requested': {
-			const label = unresolvedCount && unresolvedCount > 0
-				? `Changes Requested (${unresolvedCount})`
+			const label = openThreadCount && openThreadCount > 0
+				? `Changes Requested (${openThreadCount})`
 				: 'Changes Requested';
 			return { label, icon: '✗', className: 'status-changes' };
 		}

--- a/extension/lib/utils.ts
+++ b/extension/lib/utils.ts
@@ -61,18 +61,7 @@ export function getCheckStatusDisplay(status: string) {
 
 
 export async function copyToClipboard(text: string): Promise<void> {
-	try {
-		await navigator.clipboard.writeText(text);
-	} catch {
-		const textArea = document.createElement('textarea');
-		textArea.value = text;
-		textArea.style.position = 'fixed';
-		textArea.style.left = '-9999px';
-		document.body.appendChild(textArea);
-		textArea.select();
-		document.execCommand('copy');
-		document.body.removeChild(textArea);
-	}
+	await navigator.clipboard.writeText(text);
 }
 
 export function formatRelativeTime(date: string | number | Date): string {

--- a/extension/service-worker.ts
+++ b/extension/service-worker.ts
@@ -77,7 +77,13 @@ async function updateBadgeFromSettings(data: PullRequestData): Promise<void> {
 	const { settings } = await getRuntimeConfig();
 	const totalCount = settings.pinnedTab === 'myPRs' ? data.myPRs.length : data.reviewRequests.length;
 
-	await updateBadge(totalCount);
+	if (settings.badgeCountMode === 'filters') {
+		const persisted = await storage.getBadgeCount();
+		const count = persisted ?? totalCount;
+		await updateBadge(count);
+	} else {
+		await updateBadge(totalCount);
+	}
 }
 
 async function updateBadge(count: number): Promise<void> {

--- a/extension/service-worker.ts
+++ b/extension/service-worker.ts
@@ -77,11 +77,6 @@ async function updateBadgeFromSettings(data: PullRequestData): Promise<void> {
 	const { settings } = await getRuntimeConfig();
 	const totalCount = settings.pinnedTab === 'myPRs' ? data.myPRs.length : data.reviewRequests.length;
 
-	if (settings.badgeCountMode === 'filters') {
-		// In filters mode, the popup controls the badge during its session.
-		// Update to total as a fallback for when the popup is not open.
-	}
-
 	await updateBadge(totalCount);
 }
 

--- a/extension/service-worker.ts
+++ b/extension/service-worker.ts
@@ -78,9 +78,8 @@ async function updateBadgeFromSettings(data: PullRequestData): Promise<void> {
 	const totalCount = settings.pinnedTab === 'myPRs' ? data.myPRs.length : data.reviewRequests.length;
 
 	if (settings.badgeCountMode === 'filters') {
-		// In filters mode, the popup controls the badge.
-		// Still update to total as a fallback, unless a filtered count was recently sent.
-		return;
+		// In filters mode, the popup controls the badge during its session.
+		// Update to total as a fallback for when the popup is not open.
 	}
 
 	await updateBadge(totalCount);

--- a/extension/service-worker.ts
+++ b/extension/service-worker.ts
@@ -10,10 +10,12 @@ import {
 	runtimeOnInstalledAddListener,
 	runtimeOnMessageAddListener,
 	runtimeOnStartupAddListener,
+	storageLocalGet,
 	tabsCreate,
 } from './lib/extension-api';
 import { storage } from './lib/storage';
-import type { PullRequestData, RuntimeMessage, Settings, StoredProviderConfig } from './lib/types';
+import { filterPullRequests } from './lib/utils';
+import type { PullRequestData, PopupFilters, RuntimeMessage, Settings, StoredProviderConfig } from './lib/types';
 
 const ALARM_NAME = 'pr-poll';
 let cachedSettings: Settings | null = null;
@@ -78,12 +80,25 @@ async function updateBadgeFromSettings(data: PullRequestData): Promise<void> {
 	const totalCount = settings.pinnedTab === 'myPRs' ? data.myPRs.length : data.reviewRequests.length;
 
 	if (settings.badgeCountMode === 'filters') {
-		const persisted = await storage.getBadgeCount();
-		const count = persisted ?? totalCount;
-		await updateBadge(count);
-	} else {
-		await updateBadge(totalCount);
+		const persisted = await storageLocalGet<{ tabs?: Record<string, PopupFilters> }>(['searchFilters']);
+		const tabs = persisted.searchFilters?.tabs;
+		const filters = tabs?.[settings.pinnedTab];
+
+		if (filters) {
+			const items = settings.pinnedTab === 'myPRs' ? data.myPRs : data.reviewRequests;
+			const filtered = filterPullRequests(items, {
+				authors: filters.authors,
+				owners: filters.owners,
+				repos: filters.repos,
+				drafts: filters.drafts,
+				showReviewed: settings.pinnedTab === 'toReview' ? filters.showReviewed : undefined,
+			});
+			await updateBadge(filtered.length);
+			return;
+		}
 	}
+
+	await updateBadge(totalCount);
 }
 
 async function updateBadge(count: number): Promise<void> {

--- a/extension/service-worker.ts
+++ b/extension/service-worker.ts
@@ -75,8 +75,15 @@ async function restoreBadgeFromStorage(): Promise<void> {
 
 async function updateBadgeFromSettings(data: PullRequestData): Promise<void> {
 	const { settings } = await getRuntimeConfig();
-	const count = settings.pinnedTab === 'myPRs' ? data.myPRs.length : data.reviewRequests.length;
-	await updateBadge(count);
+	const totalCount = settings.pinnedTab === 'myPRs' ? data.myPRs.length : data.reviewRequests.length;
+
+	if (settings.badgeCountMode === 'filters') {
+		// In filters mode, the popup controls the badge.
+		// Still update to total as a fallback, unless a filtered count was recently sent.
+		return;
+	}
+
+	await updateBadge(totalCount);
 }
 
 async function updateBadge(count: number): Promise<void> {
@@ -176,10 +183,16 @@ const messageHandlers: Record<RuntimeMessage['type'], (message: RuntimeMessage) 
 	SETTINGS_UPDATED: async (message) => {
 		if ('settings' in message) {
 			cachedSettings = cachedSettings ? { ...cachedSettings, ...message.settings } : await storage.getSettings();
-			if (message.settings.pinnedTab) {
+			if (message.settings.pinnedTab || message.settings.badgeCountMode) {
 				const data = await storage.getPullRequests();
 				await updateBadgeFromSettings(data);
 			}
+		}
+		return { success: true };
+	},
+	UPDATE_BADGE_COUNT: async (message) => {
+		if ('count' in message) {
+			await updateBadge(message.count);
 		}
 		return { success: true };
 	},

--- a/extension/src/lib/components/InteractiveGuide.svelte
+++ b/extension/src/lib/components/InteractiveGuide.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import {
 		Copy,
 		FileDiff,
@@ -8,9 +8,9 @@
 	} from "lucide-svelte";
 	import SectionCard from "./SectionCard.svelte";
 
-	let activeTooltip = $state(null);
+	let activeTooltip = $state<string | null>(null);
 
-	const tooltips = {
+	const tooltips: Record<string, string> = {
 		title: "Opens Pull Request on GitHub",
 		copyPR: "Copies PR link",
 		repo: "Opens repository on GitHub",
@@ -19,7 +19,7 @@
 		branch: "Opens branch on GitHub",
 		copyBranch: "Copies branch name",
 		statusChecks: "Opens PR checks tab on GitHub",
-		statusReview: "Shows review status",
+		statusReview: "Opens review on GitHub",
 	};
 
 	// Context-aware color legend based on which element is hovered
@@ -49,7 +49,7 @@
 	let activeLegend = $derived(legendSets[activeTooltip] || legendSets.default);
 
 	// When hovering a legend pill, override card colors and text
-	let legendHoverTone = $state(null); // 'success' | 'warning' | 'danger' | null
+	let legendHoverTone = $state<string | null>(null);
 
 	const checkLabels = { success: 'All checks passed', warning: 'Checks pending', danger: 'Checks failed' };
 	const reviewLabels = { success: 'Approved', warning: 'Review pending', danger: 'Changes requested' };
@@ -65,7 +65,7 @@
 	let mouseX = $state(0);
 	let mouseY = $state(0);
 
-	function handleMousemove(e) {
+	function handleMousemove(e: MouseEvent) {
 		mouseX = e.clientX;
 		mouseY = e.clientY;
 	}
@@ -77,7 +77,7 @@
 	<!-- Tooltip Overlay -->
 	{#if activeTooltip}
 		<div
-			class="pointer-events-none fixed z-50 max-w-50 -translate-x-1/2 -translate-y-[120%] rounded-lg border border-soft bg-(--bg-panel-strong) px-3 py-2 text-center text-xs text-white shadow-xl transition-opacity animate-in fade-in duration-200"
+			class="pointer-events-none fixed z-50 max-w-50 -translate-x-1/2 translate-y-[-120%] rounded-lg border border-soft bg-(--bg-panel-strong) px-3 py-2 text-center text-xs text-white shadow-xl transition-opacity animate-in fade-in duration-200"
 			style="left: {mouseX}px; top: {mouseY}px;"
 		>
 			{tooltips[activeTooltip]}

--- a/extension/src/popup/App.svelte
+++ b/extension/src/popup/App.svelte
@@ -47,6 +47,7 @@
 			repos: [],
 			ageRange: '',
 			drafts: 'exclude',
+			showReviewed: false,
 		};
 	}
 
@@ -64,6 +65,7 @@
 			repos: [...filters.repos],
 			ageRange: filters.ageRange,
 			drafts: filters.drafts,
+			showReviewed: filters.showReviewed,
 		};
 	}
 
@@ -152,6 +154,7 @@
 			owners?: string[];
 			repos?: string[];
 			drafts?: 'only' | 'include' | 'exclude';
+			showReviewed?: boolean;
 		}
 	): PullRequest[] {
 		let result = items;
@@ -186,6 +189,11 @@
 			});
 		}
 
+		// 5. Filter by review status (hide already-reviewed when showReviewed is false)
+		if (filters.showReviewed === false) {
+			result = result.filter((pr) => pr.reviews.status === 'pending');
+		}
+
 		return result;
 	}
 
@@ -204,6 +212,7 @@
 		const repos = toStringArray(storedFilters.repos);
 		const ageRange = typeof storedFilters.ageRange === 'string' ? storedFilters.ageRange : '';
 		const drafts = storedFilters.drafts === 'only' || storedFilters.drafts === 'include' ? storedFilters.drafts : 'exclude';
+		const showReviewed = typeof storedFilters.showReviewed === 'boolean' ? storedFilters.showReviewed : false;
 
 		return {
 			...DEFAULT_FILTERS,
@@ -212,6 +221,7 @@
 			owners,
 			ageRange,
 			drafts,
+			showReviewed,
 		};
 	}
 
@@ -469,13 +479,14 @@
 	let searchActive = $derived(isSearchOpen || searchQuery.trim().length > 0);
 	// Age filter is temporarily disabled. Restore the commented ageRange count when re-enabling it.
 	// let filterCount = $derived(activeFilters.authors.length + activeFilters.owners.length + activeFilters.repos.length + Number(Boolean(activeFilters.ageRange)));
-	let filterCount = $derived(activeFilters.authors.length + activeFilters.owners.length + activeFilters.repos.length + (activeFilters.drafts !== 'exclude' ? 1 : 0));
+	let filterCount = $derived(activeFilters.authors.length + activeFilters.owners.length + activeFilters.repos.length + (activeFilters.drafts !== 'exclude' ? 1 : 0) + (activeFilters.showReviewed ? 1 : 0));
 	let filterActive = $derived(filterCount > 0);
 	let preSearchItems = $derived(filterPullRequests(currentItems, {
 		authors: activeFilters.authors,
 		owners: activeFilters.owners,
 		repos: activeFilters.repos,
 		drafts: activeFilters.drafts,
+		showReviewed: currentTab === 'toReview' ? activeFilters.showReviewed : undefined,
 	}));
 	let fuseIndex = $derived.by(() => {
 		const searchInput: SearchablePullRequest[] = preSearchItems.map((pr) => ({
@@ -526,6 +537,37 @@
 			console.error('Failed to clear persisted filter state:', error);
 		});
 	});
+
+	// Sync filtered count to badge when badgeCountMode is 'filters'
+	let totalCount = $derived(currentTab === 'myPRs' ? myPrCount : reviewCount);
+
+	$effect(() => {
+		if (settings.badgeCountMode !== 'filters') {
+			return;
+		}
+
+		const targetCount = searchActive || filterActive ? filteredItems.length : totalCount;
+		void runtimeSendMessage({ type: 'UPDATE_BADGE_COUNT', count: targetCount }).catch((error) => {
+			console.error('Failed to update badge count:', error);
+		});
+	});
+
+	// Revert badge to total count when popup closes
+	$effect(() => {
+		function revertBadge() {
+			if (settings.badgeCountMode === 'filters') {
+				void runtimeSendMessage({ type: 'UPDATE_BADGE_COUNT', count: totalCount }).catch(() => {});
+			}
+		}
+
+		window.addEventListener('pagehide', revertBadge);
+		window.addEventListener('beforeunload', revertBadge);
+
+		return () => {
+			window.removeEventListener('pagehide', revertBadge);
+			window.removeEventListener('beforeunload', revertBadge);
+		};
+	});
 </script>
 
 
@@ -561,6 +603,7 @@
 						hasAuthorFilter={hasAuthorFilter}
 						hasOwnerFilter={hasOwnerFilter}
 						hasRepoFilter={hasRepoFilter}
+						isToReviewTab={currentTab === 'toReview'}
 						bind:query={searchQuery}
 						bind:activeFilters={activeFilters}
 						bind:isSearchOpen={isSearchOpen}

--- a/extension/src/popup/App.svelte
+++ b/extension/src/popup/App.svelte
@@ -23,6 +23,7 @@
 	import { DEFAULT_SETTINGS } from '../../lib/ui-config';
 	import {
 		copyToClipboard,
+		filterPullRequests,
 		formatRelativeTime,
 		isValidHttpUrl,
 	} from '../../lib/utils';
@@ -145,57 +146,6 @@
 		);
 
 		return uniqueReposList;
-	}
-
-	function filterPullRequests(
-		items: PullRequest[],
-		filters: {
-			authors?: string[];
-			owners?: string[];
-			repos?: string[];
-			drafts?: 'only' | 'include' | 'exclude';
-			showReviewed?: boolean;
-		}
-	): PullRequest[] {
-		let result = items;
-
-		// 1. Filter by Drafts
-		if (filters.drafts === 'exclude') {
-			result = result.filter((pr) => !pr.isDraft);
-		} else if (filters.drafts === 'only') {
-			result = result.filter((pr) => pr.isDraft);
-		}
-
-		// 2. Filter by Author
-		if (filters.authors && filters.authors.length > 0) {
-			result = result.filter((pr) => {
-				const authorLogin = pr.author?.login || '';
-				return filters.authors!.includes(authorLogin);
-			});
-		}
-
-		// 3. Filter by Repository
-		if (filters.repos && filters.repos.length > 0) {
-			result = result.filter((pr) => {
-				return filters.repos!.includes(pr.repoFullName);
-			});
-		}
-
-		// 4. Filter by Owner
-		if (filters.owners && filters.owners.length > 0) {
-			result = result.filter((pr) => {
-				const ownerLogin = pr.repoOwner?.login || pr.repoFullName?.split('/')[0] || '';
-				return filters.owners!.includes(ownerLogin);
-			});
-		}
-
-		// 5. Filter by review status (hide approved PRs when showReviewed is false —
-		//    changes_requested PRs still need attention, so keep them visible)
-		if (filters.showReviewed === false) {
-			result = result.filter((pr) => pr.reviews.status !== 'approved');
-		}
-
-		return result;
 	}
 
 	function toStringArray(value: unknown): string[] {
@@ -568,8 +518,6 @@
 		void runtimeSendMessage({ type: 'UPDATE_BADGE_COUNT', count: targetCount }).catch((error) => {
 			console.error('Failed to update badge count:', error);
 		});
-		// ponytail: persist so service worker can restore filtered count on browser start before popup opens
-		void storage.setBadgeCount(targetCount).catch(() => {});
 	});
 </script>
 

--- a/extension/src/popup/App.svelte
+++ b/extension/src/popup/App.svelte
@@ -189,9 +189,10 @@
 			});
 		}
 
-		// 5. Filter by review status (hide already-reviewed when showReviewed is false)
+		// 5. Filter by review status (hide approved PRs when showReviewed is false —
+		//    changes_requested PRs still need attention, so keep them visible)
 		if (filters.showReviewed === false) {
-			result = result.filter((pr) => pr.reviews.status === 'pending');
+			result = result.filter((pr) => pr.reviews.status !== 'approved');
 		}
 
 		return result;
@@ -539,14 +540,31 @@
 	});
 
 	// Sync filtered count to badge when badgeCountMode is 'filters'
-	let totalCount = $derived(currentTab === 'myPRs' ? myPrCount : reviewCount);
+	// Always use the pinned (default) tab's data — never the current popup tab
+	let pinnedTabItems = $derived(settings.pinnedTab === 'myPRs' ? (prData.myPRs || []) : (prData.reviewRequests || []));
+	let pinnedTabFilters = $derived(currentTab === settings.pinnedTab ? activeFilters : filtersByTab[settings.pinnedTab]);
+	let pinnedTabFilterActive = $derived(
+		pinnedTabFilters.authors.length +
+		pinnedTabFilters.owners.length +
+		pinnedTabFilters.repos.length +
+		(pinnedTabFilters.drafts !== 'exclude' ? 1 : 0) +
+		(pinnedTabFilters.showReviewed && settings.pinnedTab === 'toReview' ? 1 : 0) > 0
+	);
+	let pinnedTabFilteredItems = $derived(filterPullRequests(pinnedTabItems, {
+		authors: pinnedTabFilters.authors,
+		owners: pinnedTabFilters.owners,
+		repos: pinnedTabFilters.repos,
+		drafts: pinnedTabFilters.drafts,
+		showReviewed: settings.pinnedTab === 'toReview' ? pinnedTabFilters.showReviewed : undefined,
+	}));
+	let totalCount = $derived(settings.pinnedTab === 'myPRs' ? myPrCount : reviewCount);
 
 	$effect(() => {
 		if (settings.badgeCountMode !== 'filters') {
 			return;
 		}
 
-		const targetCount = searchActive || filterActive ? filteredItems.length : totalCount;
+		const targetCount = pinnedTabFilterActive ? pinnedTabFilteredItems.length : totalCount;
 		void runtimeSendMessage({ type: 'UPDATE_BADGE_COUNT', count: targetCount }).catch((error) => {
 			console.error('Failed to update badge count:', error);
 		});
@@ -556,7 +574,8 @@
 	$effect(() => {
 		function revertBadge() {
 			if (settings.badgeCountMode === 'filters') {
-				void runtimeSendMessage({ type: 'UPDATE_BADGE_COUNT', count: totalCount }).catch(() => {});
+				const revertCount = pinnedTabFilterActive ? pinnedTabFilteredItems.length : totalCount;
+				void runtimeSendMessage({ type: 'UPDATE_BADGE_COUNT', count: revertCount }).catch(() => {});
 			}
 		}
 

--- a/extension/src/popup/App.svelte
+++ b/extension/src/popup/App.svelte
@@ -568,24 +568,8 @@
 		void runtimeSendMessage({ type: 'UPDATE_BADGE_COUNT', count: targetCount }).catch((error) => {
 			console.error('Failed to update badge count:', error);
 		});
-	});
-
-	// Revert badge to total count when popup closes
-	$effect(() => {
-		function revertBadge() {
-			if (settings.badgeCountMode === 'filters') {
-				const revertCount = pinnedTabFilterActive ? pinnedTabFilteredItems.length : totalCount;
-				void runtimeSendMessage({ type: 'UPDATE_BADGE_COUNT', count: revertCount }).catch(() => {});
-			}
-		}
-
-		window.addEventListener('pagehide', revertBadge);
-		window.addEventListener('beforeunload', revertBadge);
-
-		return () => {
-			window.removeEventListener('pagehide', revertBadge);
-			window.removeEventListener('beforeunload', revertBadge);
-		};
+		// ponytail: persist so service worker can restore filtered count on browser start before popup opens
+		void storage.setBadgeCount(targetCount).catch(() => {});
 	});
 </script>
 

--- a/extension/src/popup/App.svelte
+++ b/extension/src/popup/App.svelte
@@ -479,7 +479,7 @@
 	let searchActive = $derived(isSearchOpen || searchQuery.trim().length > 0);
 	// Age filter is temporarily disabled. Restore the commented ageRange count when re-enabling it.
 	// let filterCount = $derived(activeFilters.authors.length + activeFilters.owners.length + activeFilters.repos.length + Number(Boolean(activeFilters.ageRange)));
-	let filterCount = $derived(activeFilters.authors.length + activeFilters.owners.length + activeFilters.repos.length + (activeFilters.drafts !== 'exclude' ? 1 : 0) + (activeFilters.showReviewed ? 1 : 0));
+	let filterCount = $derived(activeFilters.authors.length + activeFilters.owners.length + activeFilters.repos.length + (activeFilters.drafts !== 'exclude' ? 1 : 0) + (activeFilters.showReviewed && currentTab === 'toReview' ? 1 : 0));
 	let filterActive = $derived(filterCount > 0);
 	let preSearchItems = $derived(filterPullRequests(currentItems, {
 		authors: activeFilters.authors,

--- a/extension/src/popup/PrCard.svelte
+++ b/extension/src/popup/PrCard.svelte
@@ -124,7 +124,7 @@
 		return 'pr-card-warning';
 	}
 
-	let reviewDisplay = $derived(getReviewStatusDisplay(pr.reviews?.status, pr.reviews?.unresolvedThreadCount));
+	let reviewDisplay = $derived(getReviewStatusDisplay(pr.reviews?.status, pr.reviews?.openThreadCount));
 	let checkDisplay = $derived(getCheckStatusDisplay(pr.checks?.status));
 	let jiraLink = $derived(getJiraLink(pr));
 	let branchUrl = $derived(getBranchUrl(pr));

--- a/extension/src/popup/PrCard.svelte
+++ b/extension/src/popup/PrCard.svelte
@@ -2,6 +2,7 @@
 	import {
 		Check,
 		Copy,
+		ExternalLink,
 		FileDiff,
 		FolderGit2,
 		GitBranch,
@@ -123,7 +124,7 @@
 		return 'pr-card-warning';
 	}
 
-	let reviewDisplay = $derived(getReviewStatusDisplay(pr.reviews?.status));
+	let reviewDisplay = $derived(getReviewStatusDisplay(pr.reviews?.status, pr.reviews?.unresolvedThreadCount));
 	let checkDisplay = $derived(getCheckStatusDisplay(pr.checks?.status));
 	let jiraLink = $derived(getJiraLink(pr));
 	let branchUrl = $derived(getBranchUrl(pr));
@@ -132,8 +133,15 @@
 		? 'flex flex-wrap gap-x-5 gap-y-1.5 text-xs'
 		: 'flex min-w-0 items-center gap-2.5 text-xs');
 	let checkStatusClasses = $derived(isFullpageMode
-		? 'unstyled-button status-inline transition-opacity hover:opacity-80'
-		: 'unstyled-button status-inline min-w-0 transition-opacity hover:opacity-80');
+		? 'unstyled-button status-inline group'
+		: 'unstyled-button status-inline min-w-0 group');
+	let reviewUrl = $derived(
+		pr.reviews?.status === 'changes_requested'
+			? (pr.reviews?.changesRequestedReviewId
+				? `${pr.url}#pullrequestreview-${pr.reviews.changesRequestedReviewId}`
+				: `${pr.url}/files`)
+			: pr.url
+	);
 </script>
 
 <SectionCard className={`p-3.5 transition-opacity pr-card-status ${getCardStatusClass(pr)} ${pr.isDraft ? 'opacity-80' : ''}`}>
@@ -211,11 +219,16 @@
 				>
 					<span class={`status-dot ${getDotToneClass(checkDisplay.className)}`}></span>
 					<span class="status-inline-label">{checkDisplay.label}</span>
+					<ExternalLink class="status-link-icon h-3 w-3 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
 				</button>
-				<span class={`status-inline min-w-0 ${getReviewToneClass(reviewDisplay.className)}`}>
+				<button
+				class={`unstyled-button status-inline min-w-0 group ${getReviewToneClass(reviewDisplay.className)}`}
+					onclick={() => onOpenUrl(reviewUrl)}
+				>
 					<span class={`status-dot ${getDotToneClass(reviewDisplay.className)}`}></span>
 					<span class="status-inline-label">{reviewDisplay.label}</span>
-				</span>
+					<ExternalLink class="status-link-icon h-3 w-3 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
+				</button>
 				<div class="ml-auto flex shrink-0 items-center gap-1 whitespace-nowrap text-[11px] font-medium leading-none text-dim" title={createdAtText}>
 					<Clock class="h-3 w-3" />
 					<span>{formatPrAge(pr.createdAt)}</span>

--- a/extension/src/popup/SearchFilter.svelte
+++ b/extension/src/popup/SearchFilter.svelte
@@ -67,7 +67,6 @@
         authors: false,
         owners: false,
         repos: false,
-        // age: false,
     });
 
     let searchInput = $state<HTMLInputElement | null>(null);
@@ -179,15 +178,6 @@
 
         activeFilters = { ...activeFilters, owners };
     }
-
-    /*
-    function selectAgeRange(value: string) {
-        activeFilters = {
-            ...activeFilters,
-            ageRange: activeFilters.ageRange === value ? '' : value,
-        };
-    }
-    */
 
     function clearSearch() {
         query = '';
@@ -302,8 +292,6 @@
     let showAuthorSearch = $derived(shouldShowSectionSearch(visibleAuthors.length));
     let showOwnerSearch = $derived(shouldShowSectionSearch(visibleOwners.length));
     let showRepoSearch = $derived(shouldShowSectionSearch(visibleRepos.length));
-    // Age filter is temporarily disabled. Restore the commented ageRange count when re-enabling it.
-    // let activeFilterCount = $derived(activeFilters.authors.length + activeFilters.owners.length + activeFilters.repos.length + Number(Boolean(activeFilters.ageRange)));
     let activeFilterCount = $derived(activeFilters.authors.length + activeFilters.owners.length + activeFilters.repos.length + (activeFilters.drafts !== 'exclude' ? 1 : 0) + (activeFilters.showReviewed && isToReviewTab ? 1 : 0));
     let hasActiveFilters = $derived(activeFilterCount > 0);
     let filterButtonLabel = $derived(hasMeaningfulFilters ? 'Toggle filters' : 'No additional filters available');
@@ -339,18 +327,6 @@
             value: 'Shown',
             onRemove: () => { activeFilters = { ...activeFilters, showReviewed: false }; },
         }] : []),
-        /*
-        ...(activeFilters.ageRange
-            ? [
-                    {
-                        key: `age:${activeFilters.ageRange}`,
-                        label: 'Age',
-                        value: AGE_OPTIONS.find((option) => option.value === activeFilters.ageRange)?.label || activeFilters.ageRange,
-                        onRemove: () => selectAgeRange(activeFilters.ageRange),
-                    },
-                ]
-            : []),
-        */
     ]);
 
     $effect(() => {
@@ -658,39 +634,6 @@
                             {/if}
                         </div>
                     {/if}
-
-                    <!--
-                    <div class="overflow-hidden rounded-lg border border-soft">
-                        <button
-                            class="unstyled-button flex w-full items-center justify-between px-3 py-2 text-left text-sm font-medium text-white transition hover:bg-(--bg-muted)"
-                            on:click={() => toggleSection('age')}
-                        >
-                            <span class="flex items-center gap-2">
-                                    {#if expandedSections.age}
-                                        <ChevronDown class="h-4 w-4 text-soft" />
-                                    {:else}
-                                        <ChevronRight class="h-4 w-4 text-soft" />
-                                    {/if}
-                                    <span>Age</span>
-                                </span>
-                            </button>
-
-                        {#if expandedSections.age}
-                            <div class="border-t border-soft px-3 py-2">
-                                <div class="grid grid-cols-3 gap-2">
-                                    {#each AGE_OPTIONS as option (option.value)}
-                                        <button
-                                            class={`unstyled-button rounded-md border px-2 py-1.5 text-center text-xs font-medium transition ${activeFilters.ageRange === option.value ? 'border-(--accent) bg-(--accent)/10 text-(--accent)' : 'border-soft text-soft hover:bg-(--bg-muted) hover:text-white'}`}
-                                            on:click={() => selectAgeRange(option.value)}
-                                        >
-                                            {option.label}
-                                        </button>
-                                    {/each}
-                                </div>
-                            </div>
-                        {/if}
-                    </div>
-                    -->
 
                 </div>
             </div>

--- a/extension/src/popup/SearchFilter.svelte
+++ b/extension/src/popup/SearchFilter.svelte
@@ -22,6 +22,7 @@
         repos: [],
         ageRange: '',
         drafts: 'exclude',
+        showReviewed: false,
     };
 
     interface Props {
@@ -36,6 +37,7 @@
         hasAuthorFilter?: boolean;
         hasOwnerFilter?: boolean;
         hasRepoFilter?: boolean;
+        isToReviewTab?: boolean;
         isSearchOpen?: boolean;
         isFilterOpen?: boolean;
         embedded?: boolean;
@@ -54,6 +56,7 @@
         hasAuthorFilter = false,
         hasOwnerFilter = false,
         hasRepoFilter = false,
+        isToReviewTab = false,
         isSearchOpen = $bindable(false),
         isFilterOpen = $bindable(false),
         embedded = false,
@@ -301,7 +304,7 @@
     let showRepoSearch = $derived(shouldShowSectionSearch(visibleRepos.length));
     // Age filter is temporarily disabled. Restore the commented ageRange count when re-enabling it.
     // let activeFilterCount = $derived(activeFilters.authors.length + activeFilters.owners.length + activeFilters.repos.length + Number(Boolean(activeFilters.ageRange)));
-    let activeFilterCount = $derived(activeFilters.authors.length + activeFilters.owners.length + activeFilters.repos.length + (activeFilters.drafts !== 'exclude' ? 1 : 0));
+    let activeFilterCount = $derived(activeFilters.authors.length + activeFilters.owners.length + activeFilters.repos.length + (activeFilters.drafts !== 'exclude' ? 1 : 0) + (activeFilters.showReviewed ? 1 : 0));
     let hasActiveFilters = $derived(activeFilterCount > 0);
     let filterButtonLabel = $derived(hasMeaningfulFilters ? 'Toggle filters' : 'No additional filters available');
     let filterPanelMaxHeight = $derived(fullpageMode ? 'min(40rem, calc(100vh - 13rem))' : '22rem');
@@ -329,6 +332,12 @@
             label: 'Draft PRs',
             value: activeFilters.drafts === 'only' ? 'Only' : 'Included',
             onRemove: () => { activeFilters = { ...activeFilters, drafts: 'exclude' }; },
+        }] : []),
+        ...(activeFilters.showReviewed ? [{
+            key: 'reviewed',
+            label: 'Reviewed PRs',
+            value: 'Shown',
+            onRemove: () => { activeFilters = { ...activeFilters, showReviewed: false }; },
         }] : []),
         /*
         ...(activeFilters.ageRange
@@ -479,6 +488,22 @@
                             </label>
                         </div>
                     </div>
+
+                    {#if isToReviewTab}
+                        <div class="rounded-lg border border-soft px-3 py-2">
+                            <span class="block text-sm font-medium text-white mb-2">Review Status</span>
+                            <div class="flex flex-col gap-1">
+                                <label class="flex items-center gap-3 rounded-md px-2 py-1.5 text-sm transition cursor-pointer hover:bg-(--bg-muted)">
+                                    <input type="radio" name="review_filter" value="pending" checked={!activeFilters.showReviewed} onchange={() => { activeFilters = { ...activeFilters, showReviewed: false }; }} class="h-3.5 w-3.5 border-soft bg-black/40 text-(--accent) focus:ring-(--accent)" />
+                                    <span class="min-w-0 flex-1 text-soft">Only pending review</span>
+                                </label>
+                                <label class="flex items-center gap-3 rounded-md px-2 py-1.5 text-sm transition cursor-pointer hover:bg-(--bg-muted)">
+                                    <input type="radio" name="review_filter" value="all" checked={activeFilters.showReviewed} onchange={() => { activeFilters = { ...activeFilters, showReviewed: true }; }} class="h-3.5 w-3.5 border-soft bg-black/40 text-(--accent) focus:ring-(--accent)" />
+                                    <span class="min-w-0 flex-1 text-soft">Show reviewed PRs</span>
+                                </label>
+                            </div>
+                        </div>
+                    {/if}
 
                     {#if showOwnerFilter}
                         <div class="overflow-hidden rounded-lg border border-soft">

--- a/extension/src/popup/SearchFilter.svelte
+++ b/extension/src/popup/SearchFilter.svelte
@@ -304,7 +304,7 @@
     let showRepoSearch = $derived(shouldShowSectionSearch(visibleRepos.length));
     // Age filter is temporarily disabled. Restore the commented ageRange count when re-enabling it.
     // let activeFilterCount = $derived(activeFilters.authors.length + activeFilters.owners.length + activeFilters.repos.length + Number(Boolean(activeFilters.ageRange)));
-    let activeFilterCount = $derived(activeFilters.authors.length + activeFilters.owners.length + activeFilters.repos.length + (activeFilters.drafts !== 'exclude' ? 1 : 0) + (activeFilters.showReviewed ? 1 : 0));
+    let activeFilterCount = $derived(activeFilters.authors.length + activeFilters.owners.length + activeFilters.repos.length + (activeFilters.drafts !== 'exclude' ? 1 : 0) + (activeFilters.showReviewed && isToReviewTab ? 1 : 0));
     let hasActiveFilters = $derived(activeFilterCount > 0);
     let filterButtonLabel = $derived(hasMeaningfulFilters ? 'Toggle filters' : 'No additional filters available');
     let filterPanelMaxHeight = $derived(fullpageMode ? 'min(40rem, calc(100vh - 13rem))' : '22rem');
@@ -333,7 +333,7 @@
             value: activeFilters.drafts === 'only' ? 'Only' : 'Included',
             onRemove: () => { activeFilters = { ...activeFilters, drafts: 'exclude' }; },
         }] : []),
-        ...(activeFilters.showReviewed ? [{
+        ...(activeFilters.showReviewed && isToReviewTab ? [{
             key: 'reviewed',
             label: 'Reviewed PRs',
             value: 'Shown',

--- a/extension/src/settings/App.svelte
+++ b/extension/src/settings/App.svelte
@@ -370,6 +370,22 @@
 		</SectionCard>
 
 		<SectionCard>
+			<div class="mb-4 flex items-center gap-3">
+				<div class="rounded-2xl bg-white/6 p-3 text-white">
+					<GitPullRequest class="h-5 w-5" />
+				</div>
+				<div>
+					<h2 class="text-base font-semibold text-white">Badge Count</h2>
+					<p class="text-sm text-soft">Choose what the icon badge number represents.</p>
+				</div>
+			</div>
+			<div class="grid gap-3 sm:grid-cols-2">
+				<RadioCard name="badgeCountMode" value="total" currentValue={currentSettings.badgeCountMode ?? 'total'} title="Total PRs" description="Show the total number of pull requests in the pinned tab." iconComponent={GitPullRequest} onchange={async () => { await updateSetting('badgeCountMode', 'total'); await runtimeSendMessage({ type: 'SETTINGS_UPDATED', settings: { badgeCountMode: 'total' } }); }} />
+				<RadioCard name="badgeCountMode" value="filters" currentValue={currentSettings.badgeCountMode ?? 'total'} title="Filtered PRs" description="Show the count matching your active filters and search." iconComponent={ListFilter} onchange={async () => { await updateSetting('badgeCountMode', 'filters'); await runtimeSendMessage({ type: 'SETTINGS_UPDATED', settings: { badgeCountMode: 'filters' } }); }} />
+			</div>
+		</SectionCard>
+
+		<SectionCard>
 			<div class="mb-0 flex items-center gap-3">
 				<div class="rounded-2xl bg-white/6 p-3 text-white">
 					<Sparkles class="h-5 w-5" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,8 @@
         "svelte-check": "^4.4.5",
         "tailwindcss": "^4.3.0",
         "tsx": "^4.22.4",
-        "typescript": "^5.9.3",
-        "typescript-eslint": "^8.57.0",
+        "typescript": "^6.0.3",
+        "typescript-eslint": "^8.62.1",
         "vite": "^8.0.1"
       }
     },
@@ -1458,20 +1458,20 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.2.tgz",
-      "integrity": "sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz",
+      "integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.57.2",
-        "@typescript-eslint/type-utils": "8.57.2",
-        "@typescript-eslint/utils": "8.57.2",
-        "@typescript-eslint/visitor-keys": "8.57.2",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/type-utils": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1481,22 +1481,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.57.2",
+        "@typescript-eslint/parser": "^8.62.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.2.tgz",
-      "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.1.tgz",
+      "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.57.2",
-        "@typescript-eslint/types": "8.57.2",
-        "@typescript-eslint/typescript-estree": "8.57.2",
-        "@typescript-eslint/visitor-keys": "8.57.2",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1508,18 +1508,18 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.2.tgz",
-      "integrity": "sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
+      "integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.57.2",
-        "@typescript-eslint/types": "^8.57.2",
+        "@typescript-eslint/tsconfig-utils": "^8.62.1",
+        "@typescript-eslint/types": "^8.62.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1530,18 +1530,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.2.tgz",
-      "integrity": "sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
+      "integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.57.2",
-        "@typescript-eslint/visitor-keys": "8.57.2"
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1552,9 +1552,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.2.tgz",
-      "integrity": "sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
+      "integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1565,21 +1565,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.2.tgz",
-      "integrity": "sha512-Co6ZCShm6kIbAM/s+oYVpKFfW7LBc6FXoPXjTRQ449PPNBY8U0KZXuevz5IFuuUj2H9ss40atTaf9dlGLzbWZg==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.1.tgz",
+      "integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.57.2",
-        "@typescript-eslint/typescript-estree": "8.57.2",
-        "@typescript-eslint/utils": "8.57.2",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
         "debug": "^4.4.3",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1590,13 +1590,13 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.2.tgz",
-      "integrity": "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
+      "integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1607,21 +1607,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.2.tgz",
-      "integrity": "sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
+      "integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.57.2",
-        "@typescript-eslint/tsconfig-utils": "8.57.2",
-        "@typescript-eslint/types": "8.57.2",
-        "@typescript-eslint/visitor-keys": "8.57.2",
+        "@typescript-eslint/project-service": "8.62.1",
+        "@typescript-eslint/tsconfig-utils": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1631,20 +1631,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.2.tgz",
-      "integrity": "sha512-krRIbvPK1ju1WBKIefiX+bngPs+odIQUtR7kymzPfo1POVw3jlF+nLkmexdSSd4UCbDcQn+wMBATOOmpBbqgKg==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
+      "integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.57.2",
-        "@typescript-eslint/types": "8.57.2",
-        "@typescript-eslint/typescript-estree": "8.57.2"
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1655,17 +1655,17 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.2.tgz",
-      "integrity": "sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
+      "integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/types": "8.62.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -3418,9 +3418,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3432,16 +3432,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.2.tgz",
-      "integrity": "sha512-VEPQ0iPgWO/sBaZOU1xo4nuNdODVOajPnTIbog2GKYr31nIlZ0fWPoCQgGfF3ETyBl1vn63F/p50Um9Z4J8O8A==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.1.tgz",
+      "integrity": "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.57.2",
-        "@typescript-eslint/parser": "8.57.2",
-        "@typescript-eslint/typescript-estree": "8.57.2",
-        "@typescript-eslint/utils": "8.57.2"
+        "@typescript-eslint/eslint-plugin": "8.62.1",
+        "@typescript-eslint/parser": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3452,7 +3452,7 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/undici-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pr-pulse",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pr-pulse",
-      "version": "1.3.2",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "fuse.js": "^7.1.0",
@@ -27,28 +27,28 @@
         "globals": "^17.4.0",
         "svelte-check": "^4.4.5",
         "tailwindcss": "^4.3.0",
-        "tsx": "^4.20.6",
+        "tsx": "^4.22.4",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.57.0",
         "vite": "^8.0.1"
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -68,9 +68,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -85,9 +85,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -102,9 +102,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -119,9 +119,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -136,9 +136,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -153,9 +153,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -170,9 +170,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -187,9 +187,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -204,9 +204,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -221,9 +221,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -238,9 +238,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -255,9 +255,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -272,9 +272,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -289,9 +289,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -306,9 +306,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -323,9 +323,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -340,9 +340,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -357,9 +357,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -374,9 +374,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -391,9 +391,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -408,9 +408,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -425,9 +425,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -442,9 +442,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -459,9 +459,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -476,9 +476,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -493,9 +493,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -743,14 +743,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -762,9 +762,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.123.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.123.0.tgz",
-      "integrity": "sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew==",
+      "version": "0.138.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -772,9 +772,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.13",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.13.tgz",
-      "integrity": "sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
       "cpu": [
         "arm64"
       ],
@@ -789,9 +789,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.13",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.13.tgz",
-      "integrity": "sha512-tz/v/8G77seu8zAB3A5sK3UFoOl06zcshEzhUO62sAEtrEuW/H1CcyoupOrD+NbQJytYgA4CppXPzlrmp4JZKA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
       "cpu": [
         "arm64"
       ],
@@ -806,9 +806,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.13",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.13.tgz",
-      "integrity": "sha512-8DakphqOz8JrMYWTJmWA+vDJxut6LijZ8Xcdc4flOlAhU7PNVwo2MaWBF9iXjJAPo5rC/IxEFZDhJ3GC7NHvug==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
       "cpu": [
         "x64"
       ],
@@ -823,9 +823,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.13",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.13.tgz",
-      "integrity": "sha512-4wBQFfjDuXYN/SVI8inBF3Aa+isq40rc6VMFbk5jcpolUBTe5cYnMsHZ51nFWsx3PVyyNN3vgoESki0Hmr/4BA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
       "cpu": [
         "x64"
       ],
@@ -840,9 +840,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.13",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.13.tgz",
-      "integrity": "sha512-JW/e4yPIXLms+jmnbwwy5LA/LxVwZUWLN8xug+V200wzaVi5TEGIWQlh8o91gWYFxW609euI98OCCemmWGuPrw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
       "cpu": [
         "arm"
       ],
@@ -857,13 +857,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.13",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.13.tgz",
-      "integrity": "sha512-ZfKWpXiUymDnavepCaM6KG/uGydJ4l2nBmMxg60Ci4CbeefpqjPWpfaZM7PThOhk2dssqBAcwLc6rAyr0uTdXg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -874,13 +877,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.13",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.13.tgz",
-      "integrity": "sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -891,13 +897,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.13",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.13.tgz",
-      "integrity": "sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -908,13 +917,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.13",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.13.tgz",
-      "integrity": "sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -925,13 +937,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.13",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.13.tgz",
-      "integrity": "sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -942,13 +957,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.13",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.13.tgz",
-      "integrity": "sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -959,9 +977,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.13",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.13.tgz",
-      "integrity": "sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
       "cpu": [
         "arm64"
       ],
@@ -976,9 +994,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.13",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.13.tgz",
-      "integrity": "sha512-viLS5C5et8NFtLWw9Sw3M/w4vvnVkbWkO7wSNh3C+7G1+uCkGpr6PcjNDSFcNtmXY/4trjPBqUfcOL+P3sWy/g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
       "cpu": [
         "wasm32"
       ],
@@ -986,18 +1004,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.1",
-        "@emnapi/runtime": "1.9.1",
-        "@napi-rs/wasm-runtime": "^1.1.2"
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.13",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.13.tgz",
-      "integrity": "sha512-Fqa3Tlt1xL4wzmAYxGNFV36Hb+VfPc9PYU+E25DAnswXv3ODDu/yyWjQDbXMo5AGWkQVjLgQExuVu8I/UaZhPQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
       "cpu": [
         "arm64"
       ],
@@ -1012,9 +1030,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.13",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.13.tgz",
-      "integrity": "sha512-/pLI5kPkGEi44TDlnbio3St/5gUFeN51YWNAk/Gnv6mEQBOahRBh52qVFVBpmrnU01n2yysvBML9Ynu7K4kGAQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
       "cpu": [
         "x64"
       ],
@@ -1029,9 +1047,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.13",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
-      "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1351,9 +1369,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1739,9 +1757,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1870,9 +1888,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1883,32 +1901,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2287,19 +2305,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/get-tsconfig": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob-parent": {
@@ -2801,9 +2806,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "dev": true,
       "funding": [
         {
@@ -2928,9 +2933,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "funding": [
         {
@@ -2948,7 +2953,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3098,25 +3103,15 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.13",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.13.tgz",
-      "integrity": "sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.123.0",
-        "@rolldown/pluginutils": "1.0.0-rc.13"
+        "@oxc-project/types": "=0.138.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -3125,21 +3120,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.13",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.13",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.13",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.13",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.13",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.13",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.13",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.13",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.13",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.13",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.13",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.13",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.13",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.13",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.13"
+        "@rolldown/binding-android-arm64": "1.1.4",
+        "@rolldown/binding-darwin-arm64": "1.1.4",
+        "@rolldown/binding-darwin-x64": "1.1.4",
+        "@rolldown/binding-freebsd-x64": "1.1.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
+        "@rolldown/binding-linux-arm64-musl": "1.1.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-musl": "1.1.4",
+        "@rolldown/binding-openharmony-arm64": "1.1.4",
+        "@rolldown/binding-wasm32-wasi": "1.1.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
+        "@rolldown/binding-win32-x64-msvc": "1.1.4"
       }
     },
     "node_modules/sade": {
@@ -3353,14 +3348,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3391,14 +3386,13 @@
       "optional": true
     },
     "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
+        "esbuild": "~0.28.0"
       },
       "bin": {
         "tsx": "dist/cli.mjs"
@@ -3486,17 +3480,17 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.6.tgz",
-      "integrity": "sha512-jeOXoY6N8rOfit/mZADMd0misLqjRdWBB3/S23ZQNuPcbVsfMBJutWD8b4ftdczMOsNyMBnKro0Z1Kt0HIqq5Q==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.2.tgz",
+      "integrity": "sha512-6YYPbRXTxx6bRXmOn7XdnQAy5DQNHhDgtjhDHI13oe4pY93kkcdGJWxpGwOm++/Wh0QpQhDrpIoVMrmrsI5AGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.13",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -3512,7 +3506,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.3.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -65,9 +65,13 @@
     "globals": "^17.4.0",
     "svelte-check": "^4.4.5",
     "tailwindcss": "^4.3.0",
-    "tsx": "^4.20.6",
+    "tsx": "^4.22.4",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.57.0",
     "vite": "^8.0.1"
+  },
+  "allowScripts": {
+    "fsevents@2.3.3": true,
+    "esbuild@0.27.7": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,12 +66,12 @@
     "svelte-check": "^4.4.5",
     "tailwindcss": "^4.3.0",
     "tsx": "^4.22.4",
-    "typescript": "^5.9.3",
-    "typescript-eslint": "^8.57.0",
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.62.1",
     "vite": "^8.0.1"
   },
   "allowScripts": {
     "fsevents@2.3.3": true,
-    "esbuild@0.27.7": true
+    "esbuild@0.28.1": true
   }
 }


### PR DESCRIPTION
## Summary

Resolves #3 and #20, plus a badge count mode setting, audit cleanup, and dependency bumps.

### Features

- **Reviewed PRs in To Review tab** (#3) — Radio filter toggles between "Only pending review" and "Show reviewed PRs." `getReviewedPRs()` fetches already-reviewed open PRs via GitHub search and merges them into the review requests list with dedup.

- **Unresolved comment counts** (#20) — "Changes Requested" labels show open thread count (e.g. "Changes Requested (3)"). Fetched via `/pulls/{pr}/comments`, counting top-level comments as a proxy for open threads (REST API limitation).

- **Badge count mode** — New setting (`total` | `filters`). In `filters` mode, the badge shows the count matching active filters. The service worker computes this directly from persisted filter state, so it works on browser start before the popup opens.

- **PR card UX** — Review status row is now clickable, deep-linking to `#pullrequestreview-{id}`. Both check and review rows show an ExternalLink icon on hover.

### Audit / cleanup (PONYTAIL-AUDIT.md)

- Converted `BaseProvider` to abstract class, removed throw stubs and `fallow-ignore-next-line` noise
- Inlined 5 pass-through methods into `fetchAllPullRequests()` in provider-manager
- Deleted dead exports: `storage.isOnboardingComplete()`, `storage.clearProvider()`, `providerManager.getProvider()`
- Collapsed `ProviderType` to `github`
- Removed `execCommand("copy")` fallback from `copyToClipboard`
- Moved `filterPullRequests` from App.svelte to utils.ts (shared between popup + service worker for badge count computation)
- Deleted ~55 lines of commented-out Age filter code in SearchFilter.svelte
- Added `lang="ts"` + type annotations to InteractiveGuide.svelte
- Updated InteractiveGuide hover text: "Shows review status" → "Opens review on GitHub"
- `console.log` → `console.debug` for review info logging

### Deps

tsx 4.22.4, vite 8.1.2, rolldown 1.1.4, esbuild 0.28.1, postcss 8.5.16, typescript 6.0.3, typescript-eslint 8.62.1. Added `allowScripts` for esbuild/fsevents.

### How to test

1. Open the "To Review" tab — toggle "Show reviewed PRs" in the filter panel. PRs you have approved should appear.
2. Find a PR with "Changes Requested" — the label should show open thread count in parentheses.
3. Settings page — change Badge Count Mode between Total / Filtered. Verify the badge updates. Close the popup, restart the browser — the badge should still show the correct filtered count.
4. Click a review status row on a "Changes Requested" PR — it should deep-link to the relevant review.

Closes #3, closes #20